### PR TITLE
Removed __destruct(), it breaks with PHP 7.

### DIFF
--- a/linkedin_3.2.0.1.class.php
+++ b/linkedin_3.2.0.1.class.php
@@ -177,16 +177,7 @@ class LinkedIn {
 	  $this->setApplicationSecret($config['appSecret']);
 	  $this->setCallbackUrl($config['callbackUrl']);
 	}
-	
-	/**
-   * The class destructor.
-   * 
-   * Explicitly clears LinkedIn object from memory upon destruction.
-	 */
-  public function __destruct() {
-    unset($this);
-	}
-	
+
 	/**
 	 * Bookmark a job.
 	 * 


### PR DESCRIPTION
This is for the issue described in #4.